### PR TITLE
Add Support for Email Template Creation

### DIFF
--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -29,7 +29,7 @@ module SendWithUs
         raise SendWithUs::ApiNilEmailId, 'email_id cannot be nil'
       end
 
-      payload = { email_id: email_id, recipient: to, 
+      payload = { email_id: email_id, recipient: to,
         email_data: data }
 
       if from.any?
@@ -53,7 +53,7 @@ module SendWithUs
       end
 
       payload = payload.to_json
-      SendWithUs::ApiRequest.new(@configuration).send_with(payload)
+      SendWithUs::ApiRequest.new(@configuration).post(:send, payload)
     end
 
     def drips_unsubscribe(email_address)
@@ -64,12 +64,23 @@ module SendWithUs
 
       payload = { email_address: email_address }
       payload = payload.to_json
-      
-      SendWithUs::ApiRequest.new(@configuration).drips_unsubscribe(payload)
+
+      SendWithUs::ApiRequest.new(@configuration).post(:'drips/unsubscribe', payload)
     end
 
     def emails()
       SendWithUs::ApiRequest.new(@configuration).get(:emails)
+    end
+
+    def create_template(name, subject, html, text)
+      payload = {
+        name: name,
+        subject: subject,
+        html: html,
+        text: text
+      }.to_json
+
+      SendWithUs::ApiRequest.new(@configuration).post(:emails, payload)
     end
 
   end

--- a/lib/send_with_us/api_request.rb
+++ b/lib/send_with_us/api_request.rb
@@ -12,93 +12,12 @@ module SendWithUs
       @configuration = configuration
     end
 
-    def send_with(payload)
-
-      path          = request_path(:send)
-      request       = Net::HTTP::Post.new(path, initheader = {'Content-Type' =>'application/json'})
-      request.add_field('X-SWU-API-KEY', @configuration.api_key)
-      request.add_field('X-SWU-API-CLIENT', @configuration.client_stub)
-
-      http          = Net::HTTP.new(@configuration.host, @configuration.port)
-      http.use_ssl  = use_ssl?
-      http.set_debug_output($stdout) if @configuration.debug
-
-      @response = http.request(request, payload)
-
-      case @response
-      when Net::HTTPNotFound then
-        raise SendWithUs::ApiInvalidEndpoint, path
-      when Net::HTTPForbidden then
-        raise SendWithUs::ApiInvalidKey, 'Invalid api key: ' + @configuration.api_key
-      when Net::HTTPBadRequest then
-        raise SendWithUs::ApiBadRequest, @response.body
-      when Net::HTTPSuccess then
-        puts @response.body if @configuration.debug
-        @response
-      else
-        raise SendWithUs::ApiUnknownError, 'An unknown error has occurred'
-      end
-    rescue Errno::ECONNREFUSED
-      raise SendWithUs::ApiConnectionRefused, 'The connection was refused'
-    end
-
-    def drips_unsubscribe(payload)
-
-      path          = request_path(:'drips/unsubscribe')
-      request       = Net::HTTP::Post.new(path, initheader = {'Content-Type' =>'application/json'})
-      request.add_field('X-SWU-API-KEY', @configuration.api_key)
-      request.add_field('X-SWU-API-CLIENT', @configuration.client_stub)
-
-      http          = Net::HTTP.new(@configuration.host, @configuration.port)
-      http.use_ssl  = use_ssl?
-      http.set_debug_output($stdout) if @configuration.debug
-
-      @response = http.request(request, payload)
-
-      case @response
-      when Net::HTTPNotFound then
-        raise SendWithUs::ApiInvalidEndpoint, path
-      when Net::HTTPForbidden then
-        raise SendWithUs::ApiInvalidKey, 'Invalid api key: ' + @configuration.api_key
-      when Net::HTTPBadRequest then
-        raise SendWithUs::ApiBadRequest, @response.body
-      when Net::HTTPSuccess then
-        puts @response.body if @configuration.debug
-        @response
-      else
-        raise SendWithUs::ApiUnknownError, 'An unknown error has occurred'
-      end
-    rescue Errno::ECONNREFUSED
-      raise SendWithUs::ApiConnectionRefused, 'The connection was refused'
+    def post(endpoint, payload)
+      request(Net::HTTP::Post, request_path(endpoint), payload)
     end
 
     def get(endpoint)
-      path = request_path(endpoint)
-      request = Net::HTTP::Get.new(path, initheader = {'Content-Type' =>'application/json'})
-      request.add_field('X-SWU-API-KEY', @configuration.api_key)
-      request.add_field('X-SWU-API-CLIENT', @configuration.client_stub)
-
-      http          = Net::HTTP.new(@configuration.host, @configuration.port)
-      http.use_ssl  = use_ssl?
-      http.set_debug_output($stdout) if @configuration.debug
-
-      @response = http.request(request)
-
-      case @response
-      when Net::HTTPNotFound then
-        raise SendWithUs::ApiInvalidEndpoint, path
-      when Net::HTTPForbidden then
-        raise SendWithUs::ApiInvalidKey, 'Invalid api key: ' + @configuration.api_key
-      when Net::HTTPBadRequest then
-        raise SendWithUs::ApiBadRequest, @response.body
-      when Net::HTTPSuccess
-        puts @response.body if @configuration.debug
-        @response
-      else
-        raise SendWithUs::ApiUnknownError, 'An unknown error has occurred'
-      end
-    rescue Errno::ECONNREFUSED
-      raise SendWithUs::ApiConnectionRefused, 'The connection was refused'
+      request(Net::HTTP::Get, request_path(endpoint))
     end
 
     private
@@ -111,5 +30,32 @@ module SendWithUs
         @configuration.protocol == 'https'
       end
 
+      def request(method_klass, path, payload=nil)
+        request = method_klass.new(path, initheader = {'Content-Type' =>'application/json'})
+        request.add_field('X-SWU-API-KEY', @configuration.api_key)
+        request.add_field('X-SWU-API-CLIENT', @configuration.client_stub)
+
+        http          = Net::HTTP.new(@configuration.host, @configuration.port)
+        http.use_ssl  = use_ssl?
+        http.set_debug_output($stdout) if @configuration.debug
+
+        @response = http.request(request, payload)
+
+        case @response
+        when Net::HTTPNotFound then
+          raise SendWithUs::ApiInvalidEndpoint, path
+        when Net::HTTPForbidden then
+          raise SendWithUs::ApiInvalidKey, 'Invalid api key: ' + @configuration.api_key
+        when Net::HTTPBadRequest then
+          raise SendWithUs::ApiBadRequest, @response.body
+        when Net::HTTPSuccess
+          puts @response.body if @configuration.debug
+          @response
+        else
+          raise SendWithUs::ApiUnknownError, 'An unknown error has occurred'
+        end
+      rescue Errno::ECONNREFUSED
+        raise SendWithUs::ApiConnectionRefused, 'The connection was refused'
+      end
   end
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -12,7 +12,7 @@ class TestApiRequest < MiniTest::Unit::TestCase
   def test_payload
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.send_with(@payload) )
+    assert_instance_of( Net::HTTPSuccess, @request.post(:send, @payload) )
   end
 
   def test_attachment
@@ -20,8 +20,8 @@ class TestApiRequest < MiniTest::Unit::TestCase
     email_id = 'test_fixture_1'
     result = @api.send_with(
         email_id,
-        {name: 'Ruby Unit Test', address: 'matt@sendwithus.com'},
-        {name: 'sendwithus', address: 'matt@sendwithus.com'},
+        {name: 'Ruby Unit Test', address: 'matt@example.com'},
+        {name: 'sendwithus', address: 'matt@example.com'},
         {},
         [],
         [],
@@ -33,25 +33,25 @@ class TestApiRequest < MiniTest::Unit::TestCase
   def test_unsubscribe
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.drips_unsubscribe(@payload) )
+    assert_instance_of( Net::HTTPSuccess, @request.post(:'drips/unsubscribe', @payload) )
   end
 
   def test_send_with_not_found_exception
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPNotFound.new(1.0, 404, "OK"))
-    assert_raises( SendWithUs::ApiInvalidEndpoint ) { @request.send_with(@payload) }
+    assert_raises( SendWithUs::ApiInvalidEndpoint ) { @request.post(:send, @payload) }
   end
 
   def test_send_with_unknown_exception
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPNotAcceptable.new(1.0, 406, "OK"))
-    assert_raises( SendWithUs::ApiUnknownError ) { @request.send_with(@payload) }
+    assert_raises( SendWithUs::ApiUnknownError ) { @request.post(:send, @payload) }
   end
 
   def test_send_with_connection_refused
     build_objects
     Net::HTTP.any_instance.stubs(:request).raises(Errno::ECONNREFUSED.new)
-    assert_raises( SendWithUs::ApiConnectionRefused ) { @request.send_with(@payload) }
+    assert_raises( SendWithUs::ApiConnectionRefused ) { @request.post(:send, @payload) }
   end
 
   def test_emails
@@ -64,5 +64,4 @@ class TestApiRequest < MiniTest::Unit::TestCase
     build_objects
     assert_equal( true, @request.send(:request_path, :send) == '/api/v1_0/send' )
   end
-
 end


### PR DESCRIPTION
The API supports creating email templates via a post against /emails,
but the gem does not currently support making this request.

This can be made easier by DRY-ing up the ApiRequest class to have
generic post/get methods that support any generic endpoint/payload
combination.
