### PR TITLE
Improve documentation around raised errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ begin
         'EMAIL_ID',
         { address: "user@example.com" })
     puts result
-    
+
     # with all optional params
     result = obj.send_with(
         'email_id',
@@ -46,7 +46,7 @@ begin
             address: 'company@example.com',
             reply_to: 'info@example.com' })
     puts result
-    
+
     # full cc/bcc support
     result = obj.send_with(
         'email_id',
@@ -129,6 +129,8 @@ The following errors may be generated:
 
 ```ruby
 SendWithUs::ApiInvalidEndpoint - the target URI is probably incorrect or email_id is invalid
+SendWithUs::ApiInvalidKey - the sendwithus API key is invalid
+SendWithUs::ApiBadRequest - the API request is invalid
 SendWithUs::ApiConnectionRefused - the target URI is probably incorrect
 SendWithUs::ApiUnknownError - an unhandled HTTP error occurred
 ```

--- a/lib/send_with_us/api_request.rb
+++ b/lib/send_with_us/api_request.rb
@@ -45,9 +45,10 @@ module SendWithUs
         when Net::HTTPNotFound then
           raise SendWithUs::ApiInvalidEndpoint, path
         when Net::HTTPForbidden then
-          raise SendWithUs::ApiInvalidKey, 'Invalid api key: ' + @configuration.api_key
+          raise SendWithUs::ApiInvalidKey, "Invalid api key: #{@configuration.api_key}"
         when Net::HTTPBadRequest then
-          raise SendWithUs::ApiBadRequest, @response.body
+          raise SendWithUs::ApiBadRequest,
+            "Bad request: \"#{path}\" with payload \"#{payload}\""
         when Net::HTTPSuccess
           puts @response.body if @configuration.debug
           @response

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -42,6 +42,18 @@ class TestApiRequest < MiniTest::Unit::TestCase
     assert_raises( SendWithUs::ApiInvalidEndpoint ) { @request.post(:send, @payload) }
   end
 
+  def test_send_with_forbidden_exception
+    build_objects
+    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPForbidden.new(1.0, 403, "OK"))
+    assert_raises( SendWithUs::ApiInvalidKey ) { @request.post(:send, @payload) }
+  end
+
+  def test_send_with_bad_request
+    build_objects
+    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPBadRequest.new(1.0, 400, "OK"))
+    assert_raises( SendWithUs::ApiBadRequest ) { @request.post(:send, @payload) }
+  end
+
   def test_send_with_unknown_exception
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPNotAcceptable.new(1.0, 406, "OK"))


### PR DESCRIPTION
- Add tests for additional errors that may be raised.
- Use string interpolation and better error messages
  to avoid getting Ruby errors while trying to raise
  our own.
- Update README.md to include additional errors that
  may be raised.
