### PR TITLE
Remove warning about VERSION

### DIFF
--- a/lib/send_with_us.rb
+++ b/lib/send_with_us.rb
@@ -10,4 +10,4 @@ require 'json'
 require 'send_with_us/api'
 require 'send_with_us/api_request'
 require 'send_with_us/config'
-require 'send_with_us/version'
+require 'send_with_us/version' unless defined?(SendWithUs::VERSION)


### PR DESCRIPTION
Removing warning: already initialized constant SendWithUs::VERSION
