### PR TITLE
Add a SendWithUs Attachment class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ bundle install
 - **from** - *hash* - From name/address/reply\_to
 - **cc** - *array* - array of CC addresses
 - **bcc** - *array* - array of BCC addresses
-- **files** - *array* - array of files to attach
+- **files** - *array* - array of files to attach, as strings or hashes (see below)
 - **esp\_account** - *string* - ESP account used to send email
 - **version\_name** - *string* - version of template to send
 - **headers** - *hash* - custom email headers **NOTE** only supported by some ESPs
+
 
 For any Ruby project:
 ```ruby
@@ -54,9 +55,12 @@ begin
         'template_id',
         { name: 'Matt', address: 'recipient@example.com' },
         { company_name: 'TestCo' },
-        { name: 'Company',
-            address: 'company@example.com',
-            reply_to: 'info@example.com' },
+        {
+          name: 'Company',
+          address: 'company@example.com',
+          reply_to: 'info@example.com'
+        },
+        ['path/to/attachment.txt'],
 		'esp_MYESPACCOUNT',
 		'v2') # version name
     puts result
@@ -91,7 +95,13 @@ begin
             reply_to: 'info@example.com' },
         [],
         [],
-        ['path/to/file.txt'])
+        [
+          'path/to/file.txt',
+          { filename: 'customfilename.txt', attachment: 'path/to/file.txt' },
+          { filename: 'anotherfile.txt', attachment: File.open('path/to/file.txt') },
+          { filename: 'unpersistedattachment.txt', attachment: StringIO.new("raw data") }
+        ]
+    )
     puts result
 
     # Set ESP account

--- a/lib/send_with_us.rb
+++ b/lib/send_with_us.rb
@@ -7,6 +7,7 @@ require 'net/https'
 require 'uri'
 require 'json'
 
+require 'send_with_us/attachment'
 require 'send_with_us/api'
 require 'send_with_us/api_request'
 require 'send_with_us/config'

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -51,14 +51,17 @@ module SendWithUs
         payload[:headers] = headers
       end
 
-      files.each do |path|
-        file = open(path).read
-        id = File.basename(path)
-        data = Base64.encode64(file)
-        if payload[:files].nil?
-          payload[:files] = []
+      if files.any?
+        payload[:files] = []
+
+        files.each do |file_data|
+          if file_data.is_a?(String)
+            attachment = SendWithUs::Attachment.new(file_data)
+          else
+            attachment = SendWithUs::Attachment.new(file_data[:attachment], file_data[:filename])
+          end
+          payload[:files] << { id: attachment.filename, data: attachment.encoded_data }
         end
-        payload[:files] << {id: id, data: data}
       end
 
       payload = payload.to_json

--- a/lib/send_with_us/attachment.rb
+++ b/lib/send_with_us/attachment.rb
@@ -1,0 +1,16 @@
+module SendWithUs
+  class Attachment
+    def initialize attachment, filename = nil
+      @attachment, @filename = attachment, filename
+    end
+
+    def filename
+      @filename ||= @attachment.is_a?(String) ? File.basename(@attachment) : nil
+    end
+
+    def encoded_data
+      file_data = @attachment.respond_to?(:read) ? @attachment : open(@attachment)
+      Base64.encode64(file_data.read)
+    end
+  end
+end

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end

--- a/test/lib/send_with_us/attachment_test.rb
+++ b/test/lib/send_with_us/attachment_test.rb
@@ -1,0 +1,71 @@
+require_relative '../../test_helper'
+
+class TestAttachment < MiniTest::Unit::TestCase
+  describe "#filename" do
+    describe "when a filename is explicitly declared" do
+      before do
+        @attachment = SendWithUs::Attachment.new(
+          StringIO.new("some data"),
+          "rawr.txt"
+        )
+      end
+
+      it "returns the explicit filename" do
+        assert_equal "rawr.txt", @attachment.filename
+      end
+    end
+
+    describe "when a filename is implied from a path" do
+      before do
+        @attachment = SendWithUs::Attachment.new(
+          "this/is/a/path.txt"
+        )
+      end
+
+      it "returns the basename of the path" do
+        assert_equal "path.txt", @attachment.filename
+      end
+    end
+
+    describe "when a filename is absent" do
+      before do
+        @attachment = SendWithUs::Attachment.new(
+          StringIO.new("")
+        )
+      end
+
+      it "returns nil" do
+        assert_nil @attachment.filename
+      end
+    end
+  end
+
+  describe "#encoded_data" do
+    describe "when the attachment is an IO object" do
+      before do
+        @attachment = SendWithUs::Attachment.new(
+          StringIO.new("test text")
+        )
+      end
+
+      it "returns the base 64'd content of the object" do
+        assert_equal Base64.encode64("test text"), @attachment.encoded_data
+      end
+    end
+
+    describe "when the attachment is not an IO object" do
+      before do
+        @attachment = SendWithUs::Attachment.new(
+          "path/to/file.txt"
+        )
+        @attachment.expects(:open).
+          with("path/to/file.txt").
+          returns(StringIO.new("test text"))
+      end
+
+      it "returns the base 64'd content of the file/url in question" do
+        assert_equal Base64.encode64("test text"), @attachment.encoded_data
+      end
+    end
+  end
+end


### PR DESCRIPTION
We should have a class responsible for the handling of attachment data
in our application.

This fixes several problems:

Problem #1: For users who use rails, uploaded files are stored without
their extension and have a basename that looks like this: RackMultipart20141217-17487-bhp429.

Currently there is no way to override the filename we want users to see,
despite it being provided by ActionDispatch::Http::UploadedFile.

Problem #2: Some users want to be able to just pass in raw data as an
attachment and not actually persist the data to the filesystem. This
can't occur with the code that predates this as it is coupled to the
assumption all attachments will be persisted on disk before being
attachments.

This fixes that issue by allowing the user to pass in an IO object
instead of a path. Anything that responds to #read would work in this
scenario.

Problem #3: SendWithUs is too coupled to the filesystem. This alleviates
some of this coupling by encapsulating all behavior having to do with
attachments into a single class.

This is a backwards compatible change. Thanks to @adammathys for additional input.
