### PR TITLE
Better error reporting.

### DIFF
--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -130,9 +130,7 @@ module SendWithUs
         end
       end
 
-      payload = payload.to_json
-      puts payload
-      SendWithUs::ApiRequest.new(@configuration).post(:send, payload)
+      SendWithUs::ApiRequest.new(@configuration).post(:send, payload.to_json)
     end
 
     def drips_unsubscribe(email_address)

--- a/lib/send_with_us/api_request.rb
+++ b/lib/send_with_us/api_request.rb
@@ -19,7 +19,7 @@ module SendWithUs
     def get(endpoint)
       request(Net::HTTP::Get, request_path(endpoint))
     end
-    
+
     def delete(endpoint)
       request(Net::HTTP::Delete, request_path(endpoint))
     end
@@ -51,8 +51,7 @@ module SendWithUs
         when Net::HTTPForbidden then
           raise SendWithUs::ApiInvalidKey, "Invalid api key: #{@configuration.api_key}"
         when Net::HTTPBadRequest then
-          raise SendWithUs::ApiBadRequest,
-            "Bad request: \"#{path}\" with payload \"#{payload}\""
+          raise SendWithUs::ApiBadRequest.new("There was an error processing your request: #{@response.body}, with payload: #{payload}")
         when Net::HTTPSuccess
           puts @response.body if @configuration.debug
           @response

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '1.9.0'
+  VERSION = '1.9.1'
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -37,7 +37,9 @@ class TestApiRequest < MiniTest::Unit::TestCase
 
   def test_send_with_bad_request
     build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPBadRequest.new(1.0, 400, "OK"))
+    bad_request = Net::HTTPBadRequest.new(1.0, 400, 'OK')
+    bad_request.stubs(:body).returns("This is a test body")
+    Net::HTTP.any_instance.stubs(:request).returns(bad_request)
     assert_raises( SendWithUs::ApiBadRequest ) { @request.post(:send, @payload) }
   end
 


### PR DESCRIPTION
This fixes two things. Firstly we remove the puts statement dumping payloads to stdout which was introduced probably by accident in the 1.9 bump.

Secondly, I've changed the BadRequest exception message to be more useful. Sendwithus' servers usually respond with useful error text of what the problem actually is, but until now we've ignored it.

Instead we've been passing through payloads (which is still helpful) and a path and leave it up to the developer who receives the bugsnag notification to try and guess why the request err'd. This way we will know exactly why things hit the fan and what we're sending SWU so our Bugsnag reports will be more valuable.