### PR TITLE
Allow locale parameter to work with #render API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ end
 - **email\_id** - *string* - Template ID being rendered
 - **version\_id** - *string* - Version ID to render (optional)
 - **data** - *hash* - Email data to render the template with (optional)
+- **data[:locale]** - *hash value* - This option specifies the locale to render (optional)
 
 ```ruby
 require 'rubygems'

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -149,14 +149,15 @@ module SendWithUs
     end
 
     def render(template_id, version_id = nil, template_data = {})
+      locale = template_data.delete(:locale)
+
       payload = {
         template_id: template_id,
         template_data: template_data,
       }
 
-      if version_id
-        payload[:version_id] = version_id
-      end
+      payload[:version_id] = version_id if version_id
+      payload[:locale] = locale if locale
 
       payload = payload.to_json
       SendWithUs::ApiRequest.new(@configuration).post(:'render', payload)


### PR DESCRIPTION
Now you can merge a `locale` parameter in with the data hash passed to `#render` to specify the locale to render.

```ruby
api.render(template_id, version_id, locale: "de-DE")
# or, with data:
api.render(template_id, version_id, name: "Jack Johnson", age: 21, locale: "de-DE")
```

I merged the locale param in as part of the data hash so as to allow Ruby "options" param usage (last arg is a hash), and to maintain backwards compatibility with existing implementations.

