### PR TITLE
Match customer_create method to underlying API

### DIFF
--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -245,12 +245,12 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload)
     end
 
-    def customer_create(email, data = {})
+    def customer_create(email, data = {}, locale = nil, groups = [])
       payload = {email: email}
 
-      if data && data.any?
-        payload[:data] = data
-      end
+      payload[:data] = data if data && data.any?
+      payload[:locale] = locale if locale
+      payload[:groups] = groups if groups && groups.any?
 
       payload = payload.to_json
       endpoint = "customers"


### PR DESCRIPTION
Adds support for `locale` and `groups` options to customer_create API method.

Not sure if this is on your roadmap, but this would be a useful addition. 

Note this may be a breaking change for folks passing in a data hash without curly braces. 