### PR TITLE
Use tags on drip campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,13 @@ begin
     puts result
 
     # Add customer@example.com to campaign dc_asdf1234
-    result = obj.start_on_drip_campaign('customer@example.com', 'dc_asdf1234', {location: 'Canada', total: '100.00', tags: ['tag']})
+    result = obj.start_on_drip_campaign('customer@example.com', 'dc_asdf1234')
+    puts result
+
+    OR
+
+    # Add customer@example.com to campaign dc_asdf1234, with optional: email_data, locale, tags
+    result = obj.start_on_drip_campaign('customer@example.com', 'dc_asdf1234', {total: '100.00'}, 'en-US', ['tag1', 'tag2'])
     puts result
 
     # Remove customer@example.com from campaign dc_asdf1234

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ begin
     puts result
 
     # Add customer@example.com to campaign dc_asdf1234
-    result = obj.start_on_drip_campaign('customer@example.com', 'dc_asdf1234', {location: 'Canada', total: '100.00'})
+    result = obj.start_on_drip_campaign('customer@example.com', 'dc_asdf1234', {location: 'Canada', total: '100.00', tags: ['tag']})
     puts result
 
     # Remove customer@example.com from campaign dc_asdf1234

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -186,7 +186,9 @@ module SendWithUs
       payload = {recipient_address: recipient_address}
 
       if email_data && email_data.any?
-        payload[:email_data] = email_data
+        tags = email_data.delete(:tags)
+        payload[:email_data] = email_data if email_data.any?
+        payload[:tags] = tags if tags
       end
       if locale
         payload[:locale] = locale

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -182,13 +182,14 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get(:drip_campaigns)
     end
 
-    def start_on_drip_campaign(recipient_address, drip_campaign_id, email_data={}, locale=nil)
+    def start_on_drip_campaign(recipient_address, drip_campaign_id, email_data={}, locale=nil, tags=[])
       payload = {recipient_address: recipient_address}
 
       if email_data && email_data.any?
-        tags = email_data.delete(:tags)
-        payload[:email_data] = email_data if email_data.any?
-        payload[:tags] = tags if tags
+        payload[:email_data] = email_data
+      end
+      if tags.any?
+        payload[:tags] = tags
       end
       if locale
         payload[:locale] = locale

--- a/test/lib/send_with_us/api_test.rb
+++ b/test/lib/send_with_us/api_test.rb
@@ -47,7 +47,8 @@ describe SendWithUs::Api do
   describe '#start_on_drip_campaign' do
     let(:email) { 'some@email.stub' }
     let(:drip_campaign_id) { 'dc_SoMeCampaIGnID' }
-    let(:tags) { ['some_tag'] }
+    let(:locale) { "en-US" }
+    let(:tags) { ['tag1', 'tag2'] }
     let(:endpoint) { "drip_campaigns/#{drip_campaign_id}/activate" }
 
     before { SendWithUs::ApiRequest.any_instance.expects(:post).with(endpoint, payload.to_json) }
@@ -59,15 +60,15 @@ describe SendWithUs::Api do
     end
 
     describe 'email_data & tags' do
-      let(:payload) { {recipient_address: email, email_data: {foo: 'bar'}, tags: tags} }
+      let(:payload) { {recipient_address: email, email_data: {foo: 'bar'}, tags: tags, locale: locale} }
 
-      it { subject.start_on_drip_campaign(email, drip_campaign_id, {foo: 'bar', tags: tags}) }
+      it { subject.start_on_drip_campaign(email, drip_campaign_id, {foo: 'bar'}, locale, tags) }
     end
 
     describe 'tags' do
-      let(:payload) { {recipient_address: email, tags: tags} }
+      let(:payload) { {recipient_address: email, tags: tags, locale: locale} }
 
-      it { subject.start_on_drip_campaign(email, drip_campaign_id, {tags: tags}) }
+      it { subject.start_on_drip_campaign(email, drip_campaign_id, {}, locale, tags) }
     end
   end
 end

--- a/test/lib/send_with_us/api_test.rb
+++ b/test/lib/send_with_us/api_test.rb
@@ -43,4 +43,31 @@ describe SendWithUs::Api do
       it { -> { subject.log }.must_raise ArgumentError }
     end
   end
+
+  describe '#start_on_drip_campaign' do
+    let(:email) { 'some@email.stub' }
+    let(:drip_campaign_id) { 'dc_SoMeCampaIGnID' }
+    let(:tags) { ['some_tag'] }
+    let(:endpoint) { "drip_campaigns/#{drip_campaign_id}/activate" }
+
+    before { SendWithUs::ApiRequest.any_instance.expects(:post).with(endpoint, payload.to_json) }
+
+    describe 'email_data' do
+      let(:payload) { {recipient_address: email, email_data: {foo: 'bar'}} }
+
+      it { subject.start_on_drip_campaign(email, drip_campaign_id, {foo: 'bar'}) }
+    end
+
+    describe 'email_data & tags' do
+      let(:payload) { {recipient_address: email, email_data: {foo: 'bar'}, tags: tags} }
+
+      it { subject.start_on_drip_campaign(email, drip_campaign_id, {foo: 'bar', tags: tags}) }
+    end
+
+    describe 'tags' do
+      let(:payload) { {recipient_address: email, tags: tags} }
+
+      it { subject.start_on_drip_campaign(email, drip_campaign_id, {tags: tags}) }
+    end
+  end
 end


### PR DESCRIPTION
Add ability to specify tags on start drip campaign. Appropriate api endpoint supports tags as described in api docs: https://www.sendwithus.com/docs/api#drip-campaigns