### PR TITLE
Deprecate support for Customer Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+2.0.0 - Deprecate Customer Groups API
 1.13.0 - Add support to get customer details
 1.12.0 - Customer logs endpoint added and optional parameters for logs fixed when no options sent
 1.11.5 - Added tags to drip campaign activations

--- a/README.md
+++ b/README.md
@@ -283,18 +283,6 @@ result = obj.customer_create("visha@example.com", customer_data)
 result = obj.customer_delete("visha@example.com")
 ```
 
-### Add customer to group
-
-```ruby
-obj.customer_add_to_group(email_address, group_id)
-```
-
-### Remove customer from group
-
-```ruby
-obj.customer_remove_from_group(email_address, group_id)
-```
-
 ### Get logs for customer
 This will retrieve email logs for a customer.
 
@@ -345,26 +333,6 @@ obj.create_template_version(template_id, name, subject, html, text)
 
 ```
 
-
-## Groups
-
-Groups are another way to "tag" customers in sendwithus. They can be thought of as lists.
-
-
-```ruby
-# List groups
-obj.get_groups()
-
-# Create group
-obj.create_customer_group(name, description)
-
-# Update group
-obj.update_customer_group(group_id, new_name, new_description)
-
-# Delete group
-obj.delete_customer_group(group_id)
-
-```
 
 ## Rails
 
@@ -455,7 +423,7 @@ If you're receiving an error in the 400 response range follow these steps:
 
 -   Double check the data and ID's getting passed to Sendwithus
 -   Ensure your API key is correct
--   Log and check the body of the response 
+-   Log and check the body of the response
 
 
 ## Internal

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -252,12 +252,11 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get("customers/#{email}")
     end
 
-    def customer_create(email, data = {}, locale = nil, groups = [])
+    def customer_create(email, data = {}, locale = nil)
       payload = {email: email}
 
       payload[:data] = data if data && data.any?
       payload[:locale] = locale if locale
-      payload[:groups] = groups if groups && groups.any?
 
       payload = payload.to_json
       endpoint = "customers"
@@ -266,18 +265,6 @@ module SendWithUs
 
     def customer_delete(email_address)
       endpoint = "customers/#{email_address}"
-      SendWithUs::ApiRequest.new(@configuration).delete(endpoint)
-    end
-
-    def customer_add_to_group(email_address, group_id)
-      payload = nil
-
-      endpoint = "customers/#{email_address}/groups/#{group_id}"
-      SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload)
-    end
-
-    def customer_remove_from_group(email_address, group_id)
-      endpoint = "customers/#{email_address}/groups/#{group_id}"
       SendWithUs::ApiRequest.new(@configuration).delete(endpoint)
     end
 
@@ -359,36 +346,6 @@ module SendWithUs
 
       endpoint = "templates/#{template_id}/versions"
       SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload.to_json)
-    end
-
-    def get_groups()
-      endpoint = "groups"
-      SendWithUs::ApiRequest.new(@configuration).get(endpoint)
-    end
-
-    def create_customer_group(name, description = '')
-      payload = {
-        name: name,
-        description: description
-      }
-
-      endpoint = "groups"
-      SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload.to_json)
-    end
-
-    def update_customer_group(group_id, name = '', description = '')
-      payload = {
-        name: name,
-        description: description
-      }
-
-      endpoint = "groups/#{group_id}"
-      SendWithUs::ApiRequest.new(@configuration).put(endpoint, payload.to_json)
-    end
-
-    def delete_customer_group(group_id)
-      endpoint = "groups/#{group_id}"
-      SendWithUs::ApiRequest.new(@configuration).delete(endpoint)
     end
   end
 end

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '1.13.0'
+  VERSION = '2.0.0'
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -11,9 +11,9 @@ class TestApiRequest < Minitest::Test
       :drip_campaign_id => 'dc_Rmd7y5oUJ3tn86sPJ8ESCk',
       :drip_campaign_step_id => 'dcs_yaAMiZNWCLAEGw7GLjBuGY'
     }
-    @customer = { :email => 'steve@sendwithus.com',
-                  :groups => ['grp_wnCdAjBWGeBGDUzNwGiTKc']
-                }
+    @customer = {
+      :email => 'steve@sendwithus.com'
+    }
     @template = {
       :html => '<html><head></head><body>TEST</body></html>',
       :subject  => 'A test template',
@@ -325,54 +325,9 @@ class TestApiRequest < Minitest::Test
     assert_instance_of( Net::HTTPSuccess, @request.delete(:'customers/#{@customer[:email]}'))
   end
 
-  def test_customer_add_to_group
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.post(:"customers/#{@customer[:email]})/groups/#{@customer[:email][0]}", @customer))
-  end
-
-  def test_customer_remove_from_group
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.delete(:"customers/#{@customer[:email]})/groups/#{@customer[:email][0]}"))
-  end
-
   def test_logs_with_options
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
     assert_instance_of( Net::HTTPSuccess, @request.get(:'logs?count=2&offset=10'))
-  end
-
-  def test_get_groups
-    build_objects
-    result = @api.get_groups()
-
-    assert_instance_of( Net::HTTPOK, result )
-  end
-
-  def test_create_customer_group
-    build_objects
-    result = @api.create_customer_group('testing')
-    result_id = JSON.parse(result.body)["group"]["id"]
-
-    # clean up
-    @api.delete_customer_group(result_id)
-
-    assert_instance_of( Net::HTTPOK, result )
-  end
-
-  def test_update_customer_group
-    build_objects
-    result = @api.update_customer_group(@customer[:groups][0], 'test')
-    assert_instance_of( Net::HTTPOK, result )
-  end
-
-  def delete_customer_group
-    build_objects
-    new_group =  @api.create_customer_group('deleteme')
-    new_group_id = JSON.parse(new_group.body)["group"]["id"]
-    result = @api.delete_customer_group(new_group_id)
-
-    assert_instance_of( Net::HTTPOK, result )
   end
 end


### PR DESCRIPTION
- Update README to reflect Customer Group API changes as the feature will soon be deprecated from all clients.
- Remove Customer Group API support from library