### PR TITLE
Deprecate conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ customer = obj.customer_get("visha@example.com")
 
 ```ruby
 customer_data = {:FirstName => "Visha"}
-result = obj.customer_create("visha@example.com", customer_data)
+result = obj.customer_create("visha@example.com")
 ```
 
 ### Delete a Customer
@@ -294,19 +294,6 @@ Optional Arguments:
 
 ```ruby
 obj.customer_email_log('customer@example.com', count: 1)
-```
-
-### Customer Conversion Event
-You can use the Conversion API to track conversion and revenue data events against your sent emails
-
-**NOTE:** Revenue is in cents (eg. $100.50 = 10050)
-
-```ruby
-# With Revenue
-obj.customer_conversion('customer@example.com', 10050)
-
-# Without Revenue
-obj.customer_conversion('customer@example.com')
 ```
 
 ## Templates

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -221,33 +221,6 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get("drip_campaigns/#{drip_campaign_id}/step/#{drip_campaign_step_id}/customers")
     end
 
-    # DEPRECATED: Please use 'customer_conversion' instead.
-    def add_customer_event(customer, event_name, revenue=nil)
-      warn "[DEPRECATED] 'add_customer_event' is deprecated.  Please use 'customer_conversion' instead."
-
-      payload = {event_name: event_name}
-
-      if revenue
-        payload[:revenue] = revenue
-      end
-
-      payload = payload.to_json
-      endpoint = "customers/#{customer}/conversions"
-      SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload)
-    end
-
-    def customer_conversion(customer, revenue=nil)
-      payload = {}
-
-      if revenue
-        payload[:revenue] = revenue
-      end
-
-      payload = payload.to_json
-      endpoint = "customers/#{customer}/conversions"
-      SendWithUs::ApiRequest.new(@configuration).post(endpoint, payload)
-    end
-
     def customer_get(email)
       SendWithUs::ApiRequest.new(@configuration).get("customers/#{email}")
     end

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -301,18 +301,6 @@ class TestApiRequest < Minitest::Test
     assert_equal( true, @request.send(:request_path, :send) == '/api/v1_0/send' )
   end
 
-  def test_add_user_event
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.post(:'customers/test@sendwithus.com/conversions', @payload))
-  end
-
-  def test_conversion_event
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.post(:'customers/test@sendwithus.com/conversions', @payload))
-  end
-
   def test_customer_create
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))


### PR DESCRIPTION
The "customer conversions" feature is being deprecated within
Sendwithus, so we're removing the feature from our ruby API client.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail if necessary -->
- Remove conversions from the documentation
- Bump the major version in the version.rb file
- Remove the conversion definitions from the library
- Remove the tests that related to the conversions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The feature has been deprecated within Sendwithus

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been updated to reflect these changes (with old tests removed)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.