### PR TITLE
Fix test deprecation warnings

### DIFF
--- a/lib/send_with_us/api_request.rb
+++ b/lib/send_with_us/api_request.rb
@@ -42,7 +42,7 @@ module SendWithUs
       end
 
       def request(method_klass, path, payload=nil)
-        request = method_klass.new(path, initheader = {'Content-Type' =>'application/json'})
+        request = method_klass.new(path, {'Content-Type' =>'application/json'})
         request.add_field('X-SWU-API-KEY', @configuration.api_key)
         request.add_field('X-SWU-API-CLIENT', @configuration.client_stub)
 

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -74,14 +74,14 @@ class TestApiRequest < Minitest::Test
 
   def test_send_with_with_attachment
     build_objects
-    result = @api.send_with(
+    result = @api.send_email(
       @template[:id],
       {name: 'Ruby Unit Test', address: 'matt@example.com'},
-      {data: 'I AM DATA'},
-      {name: 'sendwithus', address: 'matt@example.com'},
-      [],
-      [],
-      ['README.md']
+      data: {data: 'I AM DATA'},
+      from: {name: 'sendwithus', address: 'matt@example.com'},
+      cc: [],
+      bcc: [],
+      files: ['README.md']
     )
     assert_instance_of( Net::HTTPOK, result )
   end
@@ -89,16 +89,16 @@ class TestApiRequest < Minitest::Test
   def test_send_with_with_version
     build_objects
     email_id = 'tem_9YvYsaLW2Mw4tmPiLcVvpC'
-    result = @api.send_with(
+    result = @api.send_email(
       email_id,
       {name: 'Ruby Unit Test', address: 'matt@example.com'},
-      {data: 'I AM DATA'},
-      {name: 'sendwithus', address: 'matt@example.com'},
-      [],
-      [],
-      [],
-      '',
-      'v2'
+      data: {data: 'I AM DATA'},
+      from: {name: 'sendwithus', address: 'matt@example.com'},
+      cc: [],
+      bcc: [],
+      files: [],
+      esp_account: '',
+      version_name: 'v2'
     )
     assert_instance_of( Net::HTTPOK, result )
   end
@@ -106,17 +106,17 @@ class TestApiRequest < Minitest::Test
   def test_send_with_with_headers
     build_objects
     email_id = 'tem_9YvYsaLW2Mw4tmPiLcVvpC'
-    result = @api.send_with(
+    result = @api.send_email(
       email_id,
       {name: 'Ruby Unit Test', address: 'matt@example.com'},
-      {data: 'I AM DATA'},
-      {name: 'sendwithus', address: 'matt@example.com'},
-      [],
-      [],
-      [],
-      '',
-      'v2',
-      {'X-MY-HEADER' => 'foo'}
+      data: {data: 'I AM DATA'},
+      from: {name: 'sendwithus', address: 'matt@example.com'},
+      cc: [],
+      bcc: [],
+      files: [],
+      esp_account: '',
+      version_name: 'v2',
+      headers: {'X-MY-HEADER' => 'foo'}
     )
     assert_instance_of( Net::HTTPOK, result )
   end
@@ -124,18 +124,18 @@ class TestApiRequest < Minitest::Test
   def test_send_with_with_tags
     build_objects
     email_id = 'tem_9YvYsaLW2Mw4tmPiLcVvpC'
-    result = @api.send_with(
+    result = @api.send_email(
       email_id,
       {name: 'Ruby Unit Test', address: 'matt@example.com'},
-      {data: 'I AM DATA'},
-      {name: 'sendwithus', address: 'matt@example.com'},
-      [],
-      [],
-      [],
-      '',
-      'v2',
-      {},
-      ['tag1', 'tag2']
+      data: {data: 'I AM DATA'},
+      from: {name: 'sendwithus', address: 'matt@example.com'},
+      cc: [],
+      bcc: [],
+      files: [],
+      esp_account: '',
+      version_name: 'v2',
+      headers: {},
+      tags: ['tag1', 'tag2']
     )
     assert_instance_of( Net::HTTPOK, result )
   end


### PR DESCRIPTION
## Description
Fixed deprecation warnings in the `api_request_test`. These were deprecations using the old send_with method all are fixed to use the new send_email method.

Additionally, fixed an undefined variable warning in the ApiRequest#request method.

## Motivation and Context
Tests should not use deprecated methods.

## How Has This Been Tested?
Tests were green using ruby 2.4

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.