### PR TITLE
Deprecate the Logs list API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+4.0.0 - Deprecate Logs List API endpoint
 3.1.0 - Add `strict` option to the render call
 3.0.0 - Deprecate and remove Conversions API calls
 2.0.0 - Deprecate Customer Groups API

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -258,25 +258,6 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get(endpoint)
     end
 
-    def logs(options = {})
-      endpoint = 'logs'
-      params   = {}
-
-      params[:count]       = options[:count]       unless options[:count].nil?
-      params[:offset]      = options[:offset]      unless options[:offset].nil?
-      params[:created_gt]  = options[:created_gt]  unless options[:created_gt].nil?
-      params[:created_gte] = options[:created_gte] unless options[:created_gte].nil?
-      params[:created_lt]  = options[:created_lt]  unless options[:created_lt].nil?
-      params[:created_lte] = options[:created_lte] unless options[:created_lte].nil?
-
-      unless params.empty?
-        params   = URI.encode_www_form(params)
-        endpoint = endpoint + '?' + params
-      end
-
-      SendWithUs::ApiRequest.new(@configuration).get(endpoint)
-    end
-
     def log(log_id)
       endpoint = "logs/#{log_id}"
 

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -260,12 +260,6 @@ class TestApiRequest < Minitest::Test
     assert_instance_of( Net::HTTPSuccess, @request.get(:'drip_campaigns') )
   end
 
-  def test_get_with_params_for_logs
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.get(:'logs', {count: 10}.to_json) )
-  end
-
   def test_start_on_drip_campaign
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
@@ -311,11 +305,5 @@ class TestApiRequest < Minitest::Test
     build_objects
     Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
     assert_instance_of( Net::HTTPSuccess, @request.delete(:'customers/#{@customer[:email]}'))
-  end
-
-  def test_logs_with_options
-    build_objects
-    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.0, 200, "OK"))
-    assert_instance_of( Net::HTTPSuccess, @request.get(:'logs?count=2&offset=10'))
   end
 end

--- a/test/lib/send_with_us/api_test.rb
+++ b/test/lib/send_with_us/api_test.rb
@@ -22,21 +22,6 @@ describe SendWithUs::Api do
     it('configs') { SendWithUs::Api.new( api_key: @custom_api_key ).configuration.api_key.must_equal @custom_api_key }
   end
 
-  describe '#logs' do
-    describe 'without options' do
-      let(:options) { nil }
-      before { SendWithUs::ApiRequest.any_instance.expects(:get).with('logs') }
-
-      it { subject.logs }
-    end
-    describe 'with options' do
-      let(:options) { { count: 2 } }
-      before { SendWithUs::ApiRequest.any_instance.expects(:get).with('logs?count=2') }
-
-      it { subject.logs(options) }
-    end
-  end
-
   describe '#customer_email_log' do
     describe 'without options' do
       let(:options) { nil }


### PR DESCRIPTION
Deprecating the Log List API endpoint.

## Description
- Update README to reflect Log List API changes
- Remove Log List API support from library

## Motivation and Context
The endpoint has been deprecated and will later be removed. We are updating the client to reflect this.

## How Has This Been Tested?
Unit tests have been removed that rely on Log List API code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
