### PR TITLE
Allow send_email to use already encoded files (attachments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ begin
           'path/to/file.txt',
           { filename: 'customfilename.txt', attachment: 'path/to/file.txt' },
           { filename: 'anotherfile.txt', attachment: File.open('path/to/file.txt') },
-          { filename: 'unpersistedattachment.txt', attachment: StringIO.new("raw data") }
+          { filename: 'unpersistedattachment.txt', attachment: StringIO.new("raw data") },
+          { id: "alreadyBase64EncodedFile", data: "aG9sYQ==\n" }
         ]
     )
     puts result

--- a/lib/send_with_us.rb
+++ b/lib/send_with_us.rb
@@ -8,6 +8,7 @@ require 'uri'
 require 'json'
 
 require 'send_with_us/attachment'
+require 'send_with_us/file'
 require 'send_with_us/api'
 require 'send_with_us/api_request'
 require 'send_with_us/config'

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -119,15 +119,8 @@ module SendWithUs
       end
 
       if options[:files] && options[:files].any?
-        payload[:files] = []
-
-        options[:files].each do |file_data|
-          if file_data.is_a?(String)
-            attachment = SendWithUs::Attachment.new(file_data)
-          else
-            attachment = SendWithUs::Attachment.new(file_data[:attachment], file_data[:filename])
-          end
-          payload[:files] << { id: attachment.filename, data: attachment.encoded_data }
+        payload[:files] = options[:files].map do |file_data|
+          SendWithUs::File.new(file_data).to_h
         end
       end
 

--- a/lib/send_with_us/attachment.rb
+++ b/lib/send_with_us/attachment.rb
@@ -5,12 +5,17 @@ module SendWithUs
     end
 
     def filename
-      @filename ||= @attachment.is_a?(String) ? File.basename(@attachment) : nil
+      @filename ||= @attachment.is_a?(String) ? ::File.basename(@attachment) : nil
     end
 
     def encoded_data
       file_data = @attachment.respond_to?(:read) ? @attachment : open(@attachment)
       Base64.encode64(file_data.read)
+    end
+
+    def to_h
+      { id: filename,
+        data: encoded_data }
     end
   end
 end

--- a/lib/send_with_us/file.rb
+++ b/lib/send_with_us/file.rb
@@ -1,0 +1,16 @@
+module SendWithUs
+  class File < SimpleDelegator
+    def initialize(file_data, opts = {})
+      attachment = if file_data.is_a?(String)
+                     SendWithUs::Attachment.new(file_data)
+                   else
+                     if file_data[:data] and file_data[:id]
+                       file_data
+                     else
+                       SendWithUs::Attachment.new(file_data[:attachment], file_data[:filename])
+                     end
+                   end
+      super(attachment)
+    end
+  end
+end

--- a/lib/send_with_us/file.rb
+++ b/lib/send_with_us/file.rb
@@ -1,16 +1,21 @@
 module SendWithUs
-  class File < SimpleDelegator
+  class File
+    attr_accessor :attachment
+
     def initialize(file_data, opts = {})
-      attachment = if file_data.is_a?(String)
-                     SendWithUs::Attachment.new(file_data)
-                   else
-                     if file_data[:data] and file_data[:id]
-                       file_data
-                     else
-                       SendWithUs::Attachment.new(file_data[:attachment], file_data[:filename])
-                     end
-                   end
-      super(attachment)
+      @attachment = if file_data.is_a?(String)
+                      SendWithUs::Attachment.new(file_data)
+                    else
+                      if file_data[:data] and file_data[:id]
+                        file_data
+                      else
+                        SendWithUs::Attachment.new(file_data[:attachment], file_data[:filename])
+                      end
+                    end
+    end
+
+    def to_h
+      attachment.to_h
     end
   end
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -86,7 +86,7 @@ class TestApiRequest < Minitest::Test
     assert_instance_of( Net::HTTPOK, result )
   end
 
-  def test_send_with_with_file
+  def test_send_email_with_file
     build_objects
     result = @api.send_email(
       @template[:id],

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -86,6 +86,21 @@ class TestApiRequest < Minitest::Test
     assert_instance_of( Net::HTTPOK, result )
   end
 
+  def test_send_with_with_file
+    build_objects
+    result = @api.send_email(
+      @template[:id],
+      {name: 'Ruby Unit Test', address: 'matt@example.com'},
+      data: {data: 'I AM DATA'},
+      from: {name: 'sendwithus', address: 'matt@example.com'},
+      cc: [],
+      bcc: [],
+      files: [{data: Base64.encode64(open('README.md').read),
+               id: 'README.md'}]
+    )
+    assert_instance_of( Net::HTTPOK, result )
+  end
+
   def test_send_with_with_version
     build_objects
     email_id = 'tem_9YvYsaLW2Mw4tmPiLcVvpC'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail if necessary -->
These changes are with the intention to allow the `Api#send_email` to support already encoded files as params. This means if an item of the files array contains `:data` key, the specific entry will be ignored and treated as already encoded file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.