### PR TITLE
Fix encoding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+4.1.1 - Fix to encode responses as UTF-8
 4.1.0 - `send_email` now supports already encoded files
 4.0.1 - Remove unused methods
 4.0.0 - Deprecate Logs List API endpoint

--- a/lib/send_with_us/api_request.rb
+++ b/lib/send_with_us/api_request.rb
@@ -58,12 +58,12 @@ module SendWithUs
         when Net::HTTPForbidden then
           raise SendWithUs::ApiInvalidKey, "Invalid api key: #{@configuration.api_key}"
         when Net::HTTPBadRequest then
-          raise SendWithUs::ApiBadRequest.new("There was an error processing your request: #{@response.body}, with payload: #{payload}".force_encoding('ASCII-8BIT'))
+          raise SendWithUs::ApiBadRequest.new("There was an error processing your request: #{@response.body.force_encoding('UTF-8')}, with payload: #{payload}")
         when Net::HTTPSuccess
           puts @response.body if @configuration.debug
           @response
         else
-          raise SendWithUs::ApiUnknownError, "A #{@response.code} error has occurred: '#{@response.message}'"
+          raise SendWithUs::ApiUnknownError, "A #{@response.code} error has occurred: '#{@response.message.force_encoding('UTF-8')}'"
         end
       rescue Errno::ECONNREFUSED
         raise SendWithUs::ApiConnectionRefused, 'The connection was refused'

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '4.1.0'
+  VERSION = '4.1.1'
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -77,7 +77,7 @@ class TestApiRequest < Minitest::Test
     build_objects
     invalid_payload = {
       template_id:  @template[:id],
-      recipient: {name: 'Ruby Unit Test', address: 'stéve@sendwitus.com'}
+      recipient: {name: 'Ruby Unit Test', address: 'stéve@sendwithus.com'}
     }.to_json    
     assert_raises( SendWithUs::ApiBadRequest) { @request.post(:send, invalid_payload) }
   end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require_relative '../../test_helper'
 
 class TestApiRequest < Minitest::Test
@@ -72,6 +73,15 @@ class TestApiRequest < Minitest::Test
     assert_raises( SendWithUs::ApiConnectionRefused ) { @request.post(:send, @payload) }
   end
 
+  def test_send_email_with_unicode
+    build_objects
+    invalid_payload = {
+      template_id:  @template[:id],
+      recipient: {name: 'Ruby Unit Test', address: 'stéve@sendwitus.com'}
+    }.to_json    
+    assert_raises( SendWithUs::ApiBadRequest) { @request.post(:send, invalid_payload) }
+  end
+
   def test_send_with_with_attachment
     build_objects
     result = @api.send_email(
@@ -83,7 +93,7 @@ class TestApiRequest < Minitest::Test
       bcc: [],
       files: ['README.md']
     )
-    assert_instance_of( Net::HTTPOK, result )
+    assert_instance_of( Net::HTTPOK, result ) 
   end
 
   def test_send_email_with_file


### PR DESCRIPTION
## Description
This PR fixes the encoding problem mentioned in issue #78. Raising a `SendWithUs::ApiBadRequest` would result in an encoding error rather than the actual error.

## How Has This Been Tested?
A test has been added to test for this specific case.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.