### PR TITLE
Add get events method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.0
+- add a `log_events` method to get the events list on a Sendwithus log
+
 ## 4.1.1
 - Fix to encode responses as UTF-8
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,13 @@ Optional Arguments:
 obj.customer_email_log('customer@example.com', count: 1)
 ```
 
+### Get events for a single log
+This will retrieve the events and associated data for a specified log.
+
+```ruby
+obj.log_events('log_sld7xWJ3isc23-3')
+```
+
 ## Errors
 
 The following errors may be generated:

--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -249,6 +249,12 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get(endpoint)
     end
 
+    def log_events(log_id)
+      endpoint = "logs/#{log_id}/events"
+
+      SendWithUs::ApiRequest.new(@configuration).get(endpoint)
+    end
+    
     def delete_template(template_id)
       endpoint = "templates/#{template_id}"
       SendWithUs::ApiRequest.new(@configuration).delete(endpoint)

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '4.1.1'
+  VERSION = '4.2.0'
 end

--- a/test/lib/send_with_us/api_test.rb
+++ b/test/lib/send_with_us/api_test.rb
@@ -52,6 +52,19 @@ describe SendWithUs::Api do
     end
   end
 
+  describe '#log/events' do
+    describe 'with log_id' do
+      let(:log_id) { 'log_TESTTEST123' }
+      before { SendWithUs::ApiRequest.any_instance.expects(:get).with("logs/#{log_id}/events") }
+
+      it { subject.log_events(log_id) }
+    end
+
+    describe 'without log_id' do
+      it { -> { subject.log }.must_raise ArgumentError }
+    end
+  end
+
   describe '#start_on_drip_campaign' do
     let(:email) { 'some@email.stub' }
     let(:drip_campaign_id) { 'dc_SoMeCampaIGnID' }


### PR DESCRIPTION
## Description
Add a `log_events` method so events can be retrieved for an individual log.

## Motivation and Context
Fixes issue #81 and brings this more inline with the Sendwithus PHP client.

## How Has This Been Tested?
Tests have been added. This has also been tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.