### PR TITLE
Add preheader and amp_html fields to template calls

### DIFF
--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -160,12 +160,14 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).post(:'render', payload)
     end
 
-    def create_template(name, subject, html, text)
+    def create_template(name, subject, html, text, preheader='', amp_html='')
       payload = {
         name: name,
         subject: subject,
         html: html,
-        text: text
+        text: text,
+        preheader: preheader,
+        amp_html: amp_html
       }
 
       payload = payload.to_json
@@ -254,7 +256,7 @@ module SendWithUs
 
       SendWithUs::ApiRequest.new(@configuration).get(endpoint)
     end
-    
+
     def delete_template(template_id)
       endpoint = "templates/#{template_id}"
       SendWithUs::ApiRequest.new(@configuration).delete(endpoint)
@@ -270,24 +272,28 @@ module SendWithUs
       SendWithUs::ApiRequest.new(@configuration).get(endpoint)
     end
 
-    def update_template_version(template_id, version_id, name, subject, html, text)
+    def update_template_version(template_id, version_id, name, subject, html, text, preheader='', amp_html='')
       payload = {
         name: name,
         subject: subject,
         html: html,
-        text: text
+        text: text,
+        preheader: preheader,
+        amp_html: amp_html
       }
 
       endpoint = "templates/#{template_id}/versions/#{version_id}"
       SendWithUs::ApiRequest.new(@configuration).put(endpoint, payload.to_json)
     end
 
-    def create_template_version(template_id, name, subject, html, text)
+    def create_template_version(template_id, name, subject, html, text, preheader='', amp_html='')
       payload = {
         name: name,
         subject: subject,
         html: html,
-        text: text
+        text: text,
+        preheader: preheader,
+        amp_html: amp_html
       }
 
       endpoint = "templates/#{template_id}/versions"

--- a/lib/send_with_us/version.rb
+++ b/lib/send_with_us/version.rb
@@ -1,3 +1,3 @@
 module SendWithUs
-  VERSION = '4.2.1'
+  VERSION = '4.3.0'
 end

--- a/test/lib/send_with_us/api_request_test.rb
+++ b/test/lib/send_with_us/api_request_test.rb
@@ -19,7 +19,9 @@ class TestApiRequest < Minitest::Test
       :html => '<html><head></head><body>TEST</body></html>',
       :subject  => 'A test template',
       :name => 'Test Template '.concat(Random.new.rand(100000).to_s),
-      :id => 'test_fixture_1'
+      :id => 'test_fixture_1',
+      :preheader => 'Test preheader',
+      :amp_html => '<html><head></head><body>AMP HTML</body></html>'
     }
   end
 
@@ -78,7 +80,7 @@ class TestApiRequest < Minitest::Test
     invalid_payload = {
       template_id:  @template[:id],
       recipient: {name: 'Ruby Unit Test', address: 'stéve@sendwithus.com'}
-    }.to_json    
+    }.to_json
     assert_raises( SendWithUs::ApiBadRequest) { @request.post(:send, invalid_payload) }
   end
 
@@ -93,7 +95,7 @@ class TestApiRequest < Minitest::Test
       bcc: [],
       files: ['README.md']
     )
-    assert_instance_of( Net::HTTPOK, result ) 
+    assert_instance_of( Net::HTTPOK, result )
   end
 
   def test_send_email_with_file
@@ -247,6 +249,24 @@ class TestApiRequest < Minitest::Test
     assert_instance_of( Net::HTTPOK, result )
   end
 
+  def test_update_template_version_with_optional_fields
+    build_objects
+    version_id = get_first_template_version_id(@template[:id])
+
+    result = @api.update_template_version(
+      @template[:id],
+      version_id,
+      @template[:name],
+      @template[:subject],
+      @template[:html],
+      'sample text payload',
+      preheader=@template[:preheader],
+      amp_html=@template[:amp_html]
+    )
+
+    assert_instance_of( Net::HTTPOK, result )
+  end
+
   def test_create_template_version
     build_objects
     result = @api.create_template_version(
@@ -255,6 +275,21 @@ class TestApiRequest < Minitest::Test
       @template[:subject],
       @template[:html],
       ''
+    )
+
+    assert_instance_of( Net::HTTPOK, result )
+  end
+
+  def test_create_template_version_with_optional_fields
+    build_objects
+    result = @api.create_template_version(
+      @template[:id],
+      @template[:name],
+      @template[:subject],
+      @template[:html],
+      'sample text payload',
+      preheader=@template[:preheader],
+      amp_html=@template[:amp_html]
     )
 
     assert_instance_of( Net::HTTPOK, result )


### PR DESCRIPTION
Template and template version create and update calls support the
optional `preheader` and `amp_html` fields. By default these will both
be empty strings.

There is a lack of testing around the create/update calls to a template (rather than a template version) which has not been addressed in this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.