### PR TITLE
`Api#render`: allow locale to be passed in `template_data`

### DIFF
--- a/lib/send_with_us/api.rb
+++ b/lib/send_with_us/api.rb
@@ -145,7 +145,7 @@ module SendWithUs
     alias list_templates emails
 
     def render(template_id, version_id = nil, template_data = {}, strict = false)
-      locale = template_data.delete(:locale)
+      locale = template_data[:locale]
 
       payload = {
         template: template_id,

--- a/test/lib/send_with_us/api_test.rb
+++ b/test/lib/send_with_us/api_test.rb
@@ -99,4 +99,26 @@ describe SendWithUs::Api do
 
       it { subject.customer_get(email) }
   end
+
+  describe '#render' do
+    let(:locale) { 'fr-CA' }
+    let(:template_id) { 'template-id' }
+    let(:template_data) { { foo: 'bar', locale: locale } }
+    let(:strict) { true }
+    let(:version_id) { 'some-version-id' }
+
+    let(:payload) do
+      {
+        template: template_id,
+        template_data: template_data,
+        strict: strict,
+        version_id: version_id,
+        locale: locale,
+      }
+    end
+
+    before { SendWithUs::ApiRequest.any_instance.expects(:post).with(:render, payload.to_json) }
+
+    it { subject.render(template_id, version_id, template_data, strict) }
+  end
 end


### PR DESCRIPTION
## Description

Hi there! This PR allows the `render` API to be used for templates that expect to receive a key called `locale` in their template data. Currently, this method cannot be used properly for templates that happen to rely on a `locale` key in their template data as it gets omitted by the gem.

## Motivation and Context
We happen to use a key called `locale` in the template data we use with some of our Sendwithus templates. This has generally worked for us, except when using this `render` API.

This gem uses the `template_data` hash on the `render` method for two purposes:
- To set custom template data.
- To set the locale to pass to Sendwithus as the `locale` in the payload (outside of template data).

The gem currently reads the locale and **deletes it** from the template data that is sent to Sendwithus. This means the `render` method doesn't work for any template that expects to receive a key called `locale` in its `template_data`.

### Alternatively…

We could separate the `locale` option into a separate parameter and no longer pull it out of `template_data`. The upside of that approach would be we would no longer need to pass the `locale` along to the Sendwithus API inside `template_data` for **every** template. The downside is it would be a breaking change for anyone currently using this `render` method and notably, when `locale` support was originally added to this method care was taken to **not** make it a breaking change: https://github.com/sendwithus/sendwithus_ruby/pull/39.

## How Has This Been Tested?

There didn't appear to be any tests for the `render` method, but this method is listed in the README as a public API so I feel it should be tested. I added a simple test to make sure the POST call is attempted with the correct payload. This ensures the locale is passed outside of the template data, as well as within.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(I'm assuming the API will accept being passed a `locale` key in the template data when the template isn't necessarily expecting one. Please let me know if this is a bad assumption!)

Technically, this would be a breaking change for anyone who has a template that looks at the `locale` key from the template data, and is specifically relying on the fact that this `render` method is currently **not** passing that locale to Sendwithus. That feels unlikely though - if your template is looking for a `locale` in the `template_data`, surely you'd expect the `render` method to be able to pass the `locale` if it's passed in.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.